### PR TITLE
Improvements to command-line arguments. Account for on-hold jobs 

### DIFF
--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -66,11 +66,7 @@ Script accepts the following arguments:
 | --region      | GCP region where the managed instance group is located |
 | --zone        | Name of GCP zone where the managed instance group is located |
 | --group_manager | Name of the managed instance group |
-<<<<<<< HEAD
 | --verbosity (optional) | Show detail output. 1 - show basic debug info. 2 - show detail debug info |
-=======
-| --debuglevel (optional) | Detailed debug information. 1 - basic debug info. 2 - detail debug info |
->>>>>>> 878eadfcb7b287dfe1c706b6a7f67452c46f117c
 | --computeinstancelimit (optional) | Maximum number of compute nodes that can be started from the script. Default is no limit enforced by this script |
 | -h (optional) | Show command line help information |
  

--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -73,7 +73,7 @@ Script accepts the following arguments:
 Example for starting the script:
 
 ```
-python autoscaler.py --project_id=condor-cluster-project --region=us-central1 --zone=us-central1-f --group_manager=condor-compute-igm --debuglevel=2
+python autoscaler.py --project_id slurm-var-demo --region us-central1 --zone us-central1-f --group_manager condor-compute-igm --verbosity 2
 ```
 
 ### Deployment

--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -66,8 +66,8 @@ Script accepts the following arguments:
 | --region      | GCP region where the managed instance group is located |
 | --zone        | Name of GCP zone where the managed instance group is located |
 | --group_manager | Name of the managed instance group |
-| --debuglevel (optional) | Detailed debug information. 1 - basic debug info. 2 - detail debug info |
-| ----computeinstancelimit (optional) | Maximum number of compute nodes that can be started from the script. Default is no limit enforced by this script |
+| --verbosity (optional) | Show detail output. 1 - show basic debug info. 2 - show detail debug info |
+| --computeinstancelimit (optional) | Maximum number of compute nodes that can be started from the script. Default is no limit enforced by this script |
 | -h (optional) | Show command line help information |
  
 Example for starting the script:

--- a/examples/v2/htcondor/autoscaler/autoscaler.py
+++ b/examples/v2/htcondor/autoscaler/autoscaler.py
@@ -150,12 +150,14 @@ queue_length_resp = os.popen(queue_length_req).read().split()
 if len(queue_length_resp) > 1:
     queue = int(queue_length_resp[0])
     idle_jobs = int(queue_length_resp[6])
+    on_hold_jobs = int(queue_length_resp[10])
 else:
     queue = 0
     idle_jobs = 0
 
-print 'Current queue length: ' + str(queue)
+print 'Total queue length: ' + str(queue)
 print 'Idle jobs: ' + str(idle_jobs)
+print 'Jobs on hold: ' + str(on_hold_jobs)
 
 instanceTemlateInfo = getInstanceTemplateInfo()
 if debug > 1:
@@ -172,6 +174,10 @@ if debug > 1:
     print 'Currently running jobs in Condor'
     print slot_names
 
+# Adjust current queue length by the number of jos that are on-hold
+queue -=on_hold_jobs
+if on_hold_jobs>0:
+    print "Adjusted queue length: " + str(queue) 
 
 # Calculate number instances to satisfy current job queue length
 if queue > 0:

--- a/examples/v2/htcondor/autoscaler/autoscaler.py
+++ b/examples/v2/htcondor/autoscaler/autoscaler.py
@@ -27,12 +27,12 @@ import math
 import argparse
 
 parser = argparse.ArgumentParser("autoscaler.py")
-parser.add_argument("--project_id", help="Project id", type=str)
-parser.add_argument("--region", help="GCP region where the managed instance group is located", type=str)
-parser.add_argument("--zone", help="Name of GCP zone where the managed instance group is located", type=str)
-parser.add_argument("--group_manager", help="Name of the managed instance group", type=str)
-parser.add_argument("--computeinstancelimit", help="Maximum number of compute instances", type=int)
-parser.add_argument("--debuglevel", help="Show detailed debug information. 1-basic debug info. 2-detail debug info", type=int)
+parser.add_argument("-p", "--project_id", help="Project id", type=str)
+parser.add_argument("-r", "--region", help="GCP region where the managed instance group is located", type=str)
+parser.add_argument("-z", "--zone", help="Name of GCP zone where the managed instance group is located", type=str)
+parser.add_argument("-g", "--group_manager", help="Name of the managed instance group", type=str)
+parser.add_argument("-c", "--computeinstancelimit", help="Maximum number of compute instances", type=int)
+parser.add_argument("-v", "--verbosity", help="Increase output verbosity. 1-show basic debug info. 2-show detail debug info", type=int, choices=[0, 1, 2])
 args = parser.parse_args()
 
 # Project ID
@@ -55,13 +55,14 @@ size = 0
 
 # Debug level: 1-print debug information, 2 - print detail debug information
 debug = 0
-if (args.debuglevel):
-    debug = args.debuglevel
+if (args.verbosity):
+    debug = args.verbosity
 
 # Limit for the maximum number of compute instance. If zero (default setting), no limit will be enforced by the  script 
 compute_instance_limit = 0
 if (args.computeinstancelimit):
-    compute_instance_limit = args.computeinstancelimit
+    compute_instance_limit = abs(args.computeinstancelimit)
+
 
 if debug > 1:
     print 'Launching autoscaler.py with the following arguments:'


### PR DESCRIPTION
1.  Improved command-line arguments for the script
2. Changed the script to ignore on-hold jobs when calculating number of compute instances needed to handle jobs in the queue  
